### PR TITLE
fix patroni volume mountpoint ownership

### DIFF
--- a/cells/patroni/entrypoints/default.nix
+++ b/cells/patroni/entrypoints/default.nix
@@ -45,6 +45,7 @@ in {
         chmod 1777 /tmp
       fi
 
+      chown postgres:postgres "$PERSISTENCE_MOUNTPOINT"
       if [ ! -d "$PGDATA" ]; then
         mkdir -p "$PGDATA"
         chmod -R 0700 "$PERSISTENCE_MOUNTPOINT"


### PR DESCRIPTION
`walg-restore` failed because `/persist-db` was owned by `65534:65534` which combined with mode `0700` forbids any writes in its subdirectories.