### PR TITLE
Patroni observables

### DIFF
--- a/cells/bitte/alerts/bitte-alerts.nix
+++ b/cells/bitte/alerts/bitte-alerts.nix
@@ -354,13 +354,14 @@
       {
         alert = "RequestErrorsToAPI";
         expr = "increase(vm_http_request_errors_total[5m]) > 0";
-        for = "15m";
+        for = "30m";
         labels.severity = "warning";
         annotations = {
           dashboard =
             "{{ $externalURL }}/d/wNf0q_kZk?viewPanel=35&var-instance={{ $labels.instance }}";
-          description =
-            "Requests to path {{ $labels.path }} are receiving errors. Please verify if clients are sending correct requests.";
+          description = ''
+            Requests to path {{ $labels.path }} are receiving errors for more than 30m.
+             Please verify if clients are sending correct requests.'';
           summary =
             "Too many errors served for path {{ $labels.path }} (instance {{ $labels.instance }})";
         };
@@ -383,13 +384,13 @@
       {
         alert = "TooManyLogs";
         expr = ''sum(increase(vm_log_messages_total{level!="info"}[5m])) by (job, instance) > 0'';
-        for = "15m";
+        for = "30m";
         labels.severity = "warning";
         annotations = {
           dashboard =
             "{{ $externalURL }}/d/wNf0q_kZk?viewPanel=67&var-instance={{ $labels.instance }}";
           description = ''
-            Logging rate for job "{{ $labels.job }}" ({{ $labels.instance }}) is {{ $value }} for last 15m.
+            Logging rate for job "{{ $labels.job }}" ({{ $labels.instance }}) is {{ $value }} for last 30m.
              Worth to check logs for specific error messages.'';
           summary = ''
             Too many logs printed for job "{{ $labels.job }}" ({{ $labels.instance }})'';

--- a/cells/bitte/dashboards/bitte-vmalert.json
+++ b/cells/bitte/dashboards/bitte-vmalert.json
@@ -2180,7 +2180,7 @@
           "value": "vmalert"
         },
         "datasource": "$ds",
-        "definition": "label_values(vm_app_version{alias=~\"vmalert.*\"}, job)",
+        "definition": "label_values(vm_app_version{job=~\"vmalert.*\"}, job)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2190,7 +2190,7 @@
         "name": "job",
         "options": [],
         "query": {
-          "query": "label_values(vm_app_version{alias=~\"vmalert.*\"}, job)",
+          "query": "label_values(vm_app_version{job=~\"vmalert.*\"}, job)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/cells/patroni/alerts.nix
+++ b/cells/patroni/alerts.nix
@@ -1,0 +1,90 @@
+{
+  inputs,
+  cell,
+}:
+{
+  bitte-cells-patroni = {
+    datasource = "vm";
+    rules = [
+      {
+        alert = "PatroniClusterUnlocked";
+        expr = "patroni_cluster_unlocked > 0";
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            Patroni cluster has been unlocked in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }} for more than 5 minutes.'';
+          summary = "[Bitte-cells] Patroni cluster is unlocked in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }}";
+        };
+      }
+      {
+        alert = "PatroniDcsMissing";
+        expr = "rate(patroni_dcs_last_seen)[1m] == 0";
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            Patroni cluster has not checked in with the DCS in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }} for more than 5 minutes.'';
+          summary = "[Bitte-cells] Patroni cluster has not checked in with the DCS in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }}";
+        };
+      }
+      {
+        alert = "PatroniLeaderMissing";
+        expr = "sum by (namespace) (patroni_master) < 1";
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            Patroni cluster in namespace {{ $labels.namespace }} has had no leader running for more than 5 minutes.'';
+          summary = "[Bitte-cells] Patroni cluster in namespace {{ $labels.namespace }} has no leader running";
+        };
+      }
+      {
+        alert = "PatroniMemberMissing";
+        expr = "sum by (namespace) (patroni_postgres_running) < 3";
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            Patroni cluster in namespace {{ $labels.namespace }} has had only {{ $value }} member(s) running for more than 5 minutes.'';
+          summary = "[Bitte-cells] Patroni cluster in namespace {{ $labels.namespace }} has less than three members running";
+        };
+      }
+      {
+        alert = "PatroniReplicaMissing";
+        expr = "sum by (namespace) (patroni_replica) == 0";
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            Patroni cluster in namespace {{ $labels.namespace }} has had no replicas available for more than 5 minutes.'';
+          summary = "[Bitte-cells] Patroni cluster in namespace {{ $labels.namespace }} has no replicas available";
+        };
+      }
+      {
+        alert = "PatroniTimelineIncreasing";
+        expr = "rate(patroni_postgres_timeline)[1h] > 2";
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+             The patroni postgres timeline has increased by an average of {{ $value }} timelines
+              over the past hour in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }}.'';
+          summary = "[Bitte-cells] Patroni timeline is increasing rapidly in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }}";
+        };
+      }
+      {
+        alert = "PatroniXlogPaused";
+        expr = "patroni_xlog_paused > 0";
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            Patroni cluster has an xlog paused in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }} for more than 5 minutes.'';
+          summary = "[Bitte-cells] Patroni cluster has an xlog paused in namespace {{ $labels.namespace }} on allocation {{ $labels.nomad_alloc_name }}";
+        };
+      }
+    ];
+  };
+}
+

--- a/cells/patroni/alerts.nix
+++ b/cells/patroni/alerts.nix
@@ -63,7 +63,7 @@
       }
       {
         alert = "PatroniTimelineIncreasing";
-        expr = "rate(patroni_postgres_timeline)[1h] > 2";
+        expr = "sum_over_time(rate(patroni_postgres_timeline)[1h]) > 2";
         for = "5m";
         labels.severity = "critical";
         annotations = {

--- a/cells/patroni/dashboards.nix
+++ b/cells/patroni/dashboards.nix
@@ -1,0 +1,20 @@
+{
+  inputs,
+  cell,
+}: let
+  # Since dashboards will exist as either JSON already, or will
+  # be converted to JSON from Nix (ex: Grafonnix), dashboard attrs
+  # are expected to have values of JSON strings.
+
+  importAsJson = file: builtins.readFile file;
+  # importGrafonnixToJson = ...;
+in {
+  bitte-cells-patroni = importAsJson ./dashboards/patroni.json;
+
+  # Upstream dashboards can be imported here, instead of directly
+  # imported in the hydrationProfile.  This will allow easier
+  # re-export of repo related dashboards which might have downstream
+  # re-use.
+  # inherit (inputs.X.Y.dashboards)
+  # ;
+}

--- a/cells/patroni/dashboards/patroni.json
+++ b/cells/patroni/dashboards/patroni.json
@@ -1,0 +1,1421 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VICTORIAMETRICS",
+      "label": "VictoriaMetrics",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1658277638425,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Postgres timeline of this node (if running), 0 otherwise.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_postgres_timeline{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Timeline Counter",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:800",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:801",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Value is 1 if the cluster is unlocked, 0 if locked.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_cluster_unlocked{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Cluster Unlock Status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:585",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:586",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Value is 1 if Postgres is running, 0 otherwise.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_postgres_running{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Postgres Running",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Value is 1 if this node is the leader, 0 otherwise.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_master{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Master",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Value is 1 if this node is a replica, 0 otherwise.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 29,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_replica{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Replica",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Value is 1 if this node is the standby_leader, 0 otherwise.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_standby_leader{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Standby Leader",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Epoch seconds since Postgres started.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 23,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_postmaster_start_time{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Postmaster Start Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:300",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:301",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Version of Postgres (if running), 0 otherwise.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 34,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_postgres_server_version{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Postgres Server Version",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Current location of the Postgres transaction log, 0 if this node is not the leader.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 27,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_xlog_location{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Xlog Location",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Current location of the replayed Postgres transaction log, 0 if this node is not a replica.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_xlog_replayed_location{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Xlog Replayed Location",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Current location of the received Postgres transaction log, 0 if this node is not a replica.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "hiddenSeries": false,
+      "id": 30,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_xlog_received_location{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Xlog Received Location",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Current timestamp of the replayed Postgres transaction log, 0 if null.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_xlog_replayed_timestamp{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Xlog Replayed Timestamp",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Value is 1 if the Postgres xlog is paused, 0 otherwise.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "hiddenSeries": false,
+      "id": 33,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_xlog_paused{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni Xlog Paused",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Epoch timestamp when DCS was last contacted successfully.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "hiddenSeries": false,
+      "id": 35,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.0.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "patroni_dcs_last_seen{namespace=\"$namespace\"}",
+          "interval": "",
+          "legendFormat": "{{nomad_alloc_name}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Patroni DCS Last Seen Timestamp",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:357",
+          "format": "none",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:358",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "VictoriaMetrics"
+        },
+        "definition": "label_values(namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Patroni [bitte-cells]",
+  "uid": "29DHFTg4k",
+  "version": 1,
+  "weekStart": ""
+}

--- a/cells/patroni/nomadJob/default.nix
+++ b/cells/patroni/nomadJob/default.nix
@@ -67,7 +67,7 @@ in
         update.health_check = "task_states";
         update.healthy_deadline = "5m0s";
         update.max_parallel = 1;
-        update.min_healthy_time = "60s";
+        update.min_healthy_time = "2m";
         update.progress_deadline = "10m0s";
         update.stagger = "30s";
         # ----------

--- a/cells/patroni/nomadJob/default.nix
+++ b/cells/patroni/nomadJob/default.nix
@@ -102,15 +102,12 @@ in
               # Until we implement app based mTLS, or alternatively
               # generate vault pki certs for vector consumption
               # with rotation and SIGHUP consul template restarts.
-              #
-              # Undocumented option:
-              # https://github.com/vectordotdev/vector/issues/12129
               sources.prom.tls.verify_certificate = false;
 
               # Avoid repeating duplicate fingerprint logs for
               # stdout between patroni and backup-walg logs.
               sources.source_stdout.fingerprint.strategy = "checksum";
-              sources.source_stdout.fingerprint.lines = 2;
+              sources.source_stdout.fingerprint.lines = 4;
               sources.source_stdout.fingerprint.ignored_header_bytes = 0;
             };
           })

--- a/cells/patroni/nomadJob/default.nix
+++ b/cells/patroni/nomadJob/default.nix
@@ -91,12 +91,19 @@ in
           merge
           (cells.vector.nomadTask.default {
             inherit namespace;
-            # Patroni requires the rest interface to be publicly
-            # bound, accessible over the network by other cluster
-            # members and the metrics endpoint is served from the
-            # same binding.  Therefore, we need to scrape the host
-            # IP:PORT for metrics.
-            endpoints = ["https://$NOMAD_ADDR_patroni/metrics"];
+            # TODO: Once network bridge mode hairpinning is fixed
+            # switch to using the host IP to improve endpoint metrics
+            # reporting which now will report only 127.0.0.1 for each
+            # patroni member, with the distinguishing metric being
+            # nomad_alloc_id.
+            #
+            # Refs:
+            #   https://github.com/hashicorp/nomad/issues/13352
+            #   https://github.com/hashicorp/nomad/pull/13834
+            #
+            # Switch to:
+            # endpoints = ["https://$NOMAD_ADDR_patroni/metrics"];
+            endpoints = ["https://127.0.0.1:8008/metrics"];
 
             extra = {
               # Until we implement app based mTLS, or alternatively

--- a/cells/patroni/nomadJob/env-patroni.nix
+++ b/cells/patroni/nomadJob/env-patroni.nix
@@ -103,7 +103,7 @@ in {
                 #  https://patroni.readthedocs.io/en/latest/dynamic_configuration.html
                 #
                 hot_standby: on
-                max_connections: 100
+                max_connections: 1024
                 max_locks_per_transaction: 64
                 max_prepared_transactions: 0
                 max_replication_slots: 10


### PR DESCRIPTION
* adds patroni alerts
* adds patroni dashboard
* change patroni default max conns to 1024 (see update comments in commit for pre-existing clusters)
* increase update time to avoid occasional replication failures
* increase vector checksum header size for log file disambiguation
* fix patroni metrics temp. w/ localhost scrape until Nomad bridge mode CNI packet hairpinning is enabled/fixed
* patroni timeline alert sensitivity improvement
* adjust for sensitivity on vm alerts caused by nomad alloc restarts and incorrect grafana explorer queries
* fix vmalert dash for vmalert-{loki,vm} jobs