### PR TITLE
utils: Expose full CA chain in workload identity

### DIFF
--- a/cells/_utils/nomadFragments.nix
+++ b/cells/_utils/nomadFragments.nix
@@ -46,7 +46,9 @@
       data = ''
         {{ with $hostIp := (env "attr.unique.network.ip-address") }}
         {{ with secret "${vaultPkiPath}" (printf "common_name=%s" $hostIp) (printf "ip_sans=%s" $hostIp) "ttl=720h" }}
-        {{ .Data.issuing_ca }}
+        {{ range $cert := .Data.ca_chain }}
+        {{ $cert }}
+        {{ end }}
         {{ end }}
         {{ end }}
       '';


### PR DESCRIPTION
Since we're using 2 layers of custom CA certificates, TLS clients need to know about full chain, not just the intermediate CA cert.