### PR TITLE
imp: add vault token loop alerts; update envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,5 @@
 #! /bin/sh
 
-source_url \
-  "https://raw.githubusercontent.com/divnix/std/main/direnv_lib.sh" \
-  "sha256-RhvZbOaNE91mAm0mG65WHuSNXH/QDOmkc052XbRPjks="
-use std cells //automation/devshells:default
+# shellcheck disable=SC1090
+. "$(nix eval --raw .#__std.direnv_lib)"
+use std nix "//automation/devshells:default"

--- a/cells/bitte/alerts/bitte-alerts.nix
+++ b/cells/bitte/alerts/bitte-alerts.nix
@@ -215,6 +215,54 @@
           summary = "Detected a vault leadership loss on {{ $labels.host }}";
         };
       }
+      {
+        alert = "VaultLeaseExpirationRate";
+        expr = ''rate(vault_expire_num_leases_value[1m]) * 60 > 25'';
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            More than 25 expired vault leases per minute have occured on {{ $labels.host }} for the past 5 minutes.
+              This should be investigated to ensure vault is not stuck in a lease loop.'';
+          summary = "High lease expiration rate on {{ $labels.host }} -- investigation needed";
+        };
+      }
+      {
+        alert = "VaultLeaseExpirationIncrease";
+        expr = ''increase(vault_expire_num_leases_value[10m]) > 100'';
+        for = "2m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            More than 100 expired vault leases have occurred on {{ $labels.host }} in the past 10 minutes.
+              This should be investigated to ensure vault is not stuck in a lease loop.'';
+          summary = "High lease expiration increase on {{ $labels.host }} -- investigation needed";
+        };
+      }
+      {
+        alert = "VaultTokenCountRate";
+        expr = ''rate(vault_token_count_value[1m]) * 60 > 25'';
+        for = "5m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            More than 25 new vault tokens per minute have been created on {{ $labels.host }} for the past 5 minutes.
+              This should be investigated to ensure vault is not stuck in a token loop.'';
+          summary = "High token creation rate on {{ $labels.host }} -- investigation needed";
+        };
+      }
+      {
+        alert = "VaultTokenCountIncrease";
+        expr = ''increase(vault_token_count_value[10m]) > 100'';
+        for = "2m";
+        labels.severity = "critical";
+        annotations = {
+          description = ''
+            More than 100 new vault tokens have been created on {{ $labels.host }} in the past 10 minutes.
+             This should be investigated to ensure vault is not stuck in a token loop.'';
+          summary = "High token increase on {{ $labels.host }} -- investigation needed";
+        };
+      }
     ];
   };
 


### PR DESCRIPTION
* Alerts for fairly rare situations where vault gets stuck in a token or lease loop.
* If these situations aren't caught early, raft state in vault can bloat up to GBs in size, CRLs can hit publishing limits, and memory consumption on cores can be pushed towards destabilizing levels.
* These alerts should help us catch these rare events early.